### PR TITLE
Solve text wrapping issue of the title of card

### DIFF
--- a/src/components/ideaCard/ideaCard.css
+++ b/src/components/ideaCard/ideaCard.css
@@ -3,5 +3,8 @@
 }
 
 .ant-card-meta-title {
-    /* color: #63b275; */
+    color: #63b275;
+    text-overflow: clip;
+    white-space: pre-line;
+    overflow: hidden;
 }


### PR DESCRIPTION
# Solve text wrapping issue of the title of card

[Fix Long Heading no wrap bug](https://github.com/r-ush/khayaali-pulao/issues/5)

## Changes made

-   Changed css wrapping to no wrap, and white-space handling to pre-line on title of card

## How does the solution address the problem

Before the title had ellipsis like this: 
![nowrap](https://user-images.githubusercontent.com/35070972/94782806-61529f00-03e9-11eb-9749-ff399a4ae301.PNG)


Now the title is displayed like this:
![image](https://user-images.githubusercontent.com/35070972/94782817-657ebc80-03e9-11eb-97c4-381b63c6547f.png)


## Linked issues

Resolves #5
